### PR TITLE
Adds option to prevent FetchContent for fdpapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ project(cppSimpleModel
     LANGUAGES CXX C
 )
 
+# Option to prevent FetchContent, and force usage of pre-installed library
+option(
+    FDPAPI_NO_FETCHCONTENT
+    "If set, compilation will fail unless a pre-installed FDPAPI library is found"
+    OFF
+)
+
 set( CPPSIMPLEMODEL cppSimpleModel )
 
 # Set Output Directories to avoid issues on multi release compilers

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,21 +28,26 @@ if(NOT ghc_filesystem_FOUND)
 
 endif()
 
-find_package(fdpapi)
-if(NOT fdpapi_FOUND)
+if(FDPAPI_NO_FETCHCONTENT)
+    find_package(fdpapi REQUIRED)
+    message(STATUS "fdpapi found")
+else()
+    find_package(fdpapi)
+    if(NOT fdpapi_FOUND)
 
-    SET( FDPAPI_URL "https://github.com/FAIRDataPipeline/cppDataPipeline/archive/refs/${CPPDATAPIPELINEREF}.zip" )
+        SET( FDPAPI_URL "https://github.com/FAIRDataPipeline/cppDataPipeline/archive/refs/${CPPDATAPIPELINEREF}.zip" )
 
-    MESSAGE( STATUS "[FDPAPI]" )
-    MESSAGE( STATUS "\tFDPAPI Will be installed." )
-    MESSAGE( STATUS "\tURL: ${FDPAPI_URL}" )
+        MESSAGE( STATUS "[FDPAPI]" )
+        MESSAGE( STATUS "\tFDPAPI Will be installed." )
+        MESSAGE( STATUS "\tURL: ${FDPAPI_URL}" )
 
-    include(FetchContent)
-    FetchContent_Declare(
-        FDPApi
-        URL ${FDPAPI_URL}
-    )
-    FetchContent_MakeAvailable(FDPApi)
+        include(FetchContent)
+        FetchContent_Declare(
+            FDPApi
+            URL ${FDPAPI_URL}
+        )
+        FetchContent_MakeAvailable(FDPApi)
+    endif()
 endif()
 
 SET( SCIPLOT_URL "https://github.com/RyanJField/sciplot/archive/refs/heads/master.zip" )


### PR DESCRIPTION
Adds an option to force the use of `find_package` and prevent `FetchContent` when building against cppDataPipeline. This allows us to test whether cppDataPipeline can be installed on a user's system and used for their projects without re-downloading/installing FDPAPI each time.

Supports PR https://github.com/FAIRDataPipeline/cppDataPipeline/pull/37