### PR TITLE
Test Workflow: Update libraries installed using apt

### DIFF
--- a/.github/workflows/cpp_simple_model.yaml
+++ b/.github/workflows/cpp_simple_model.yaml
@@ -23,7 +23,7 @@ jobs:
         run: curl -fsSL https://data.scrc.uk/static/localregistry.sh | /bin/bash -s -- -b main
       - name: Install Dependencies
         run: |
-          sudo apt install -y lcov libjsoncpp-dev curl libcurl4-openssl-dev libyaml-cpp-dev libhdf5-dev
+          sudo apt install -y lcov curl libcurl4-openssl-dev libhdf5-dev
       - name: Configure Library
         run: |
           cmake -Bbuild


### PR DESCRIPTION
New build system for the C++ API may fail using jsoncpp and yamlcpp from the Ubuntu package manager, as these versions are behind those used by cmake FetchContent.